### PR TITLE
Updated register endpoint for registrar compatibility

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,7 +10,7 @@ servers:
   description: SwaggerHub API Auto Mocking
 - url: /1.0/
 paths:
-  /register:
+  /create:
     post:
       summary: Registers a DID.
       operationId: register

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uni-registrar-driver-did-nodejs-factom",
-  "version": "0.0.1",
+  "version": "0.0.2-SNAPSHOT",
   "description": "Factom Universal Registrar Driver",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The new UniRegistrar uses `/create` instead of `/register`. I've updated the endpoint here so that this driver is still usable. We are currently still using it in the VC API, as we don't need full DID support there at the moment, and Factom Identity backwards compatibility hasn't been added to the new driver yet.